### PR TITLE
do not push to the repo registry URLs

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,8 +39,8 @@ jobs:
         docker login ${{ env.REGISTRY_URL }} -u ${{ secrets.ACR_USERNAME }} -p ${{ secrets.ACR_PASSWORD }}
     - name: Push images to Azure Container Registry
       run: |
-        docker push ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ steps.get-version.outputs.VERSION }}
-        docker push ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:latest
+        # docker push ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ steps.get-version.outputs.VERSION }}
+        # docker push ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:latest
         # to be removed when fixing the wadden-sea-backend image in ACR
         docker push waddencr.azurecr.io/vfn-rag:latest
     - name: Show pushed images


### PR DESCRIPTION
# Description
The wadden-sea-backend repo in the azure registry has a problem at the moment and the image is being pushed with a tag vfn-rag to the vfn-rag repo in the azure registry